### PR TITLE
animation.id, animation.cancel

### DIFF
--- a/src/mocks/web-animations-api/__tests__/index.test.ts
+++ b/src/mocks/web-animations-api/__tests__/index.test.ts
@@ -35,4 +35,22 @@ describe('Animations API', () => {
     expect(element.getAnimations().length).toBe(0);
     expect(document.getAnimations().length).toBe(0);
   });
+
+  it('should read id from options and attach it to the returned animation', async () => {
+    const element = document.createElement('div');
+    const testId = 'testId';
+
+    const animation = element.animate({ opacity: 0 }, { id: testId });
+    expect(animation.id).toBe(testId);
+  });
+
+  it('should remove an animation from element if the animation was cancelled', () => {
+    const element = document.createElement('div');
+
+    const animation = element.animate({ opacity: 0 }, 1000);
+    expect(element.getAnimations().length).toBe(1);
+
+    animation.cancel();
+    expect(element.getAnimations().length).toBe(0);
+  });
 });

--- a/src/mocks/web-animations-api/__tests__/index.test.ts
+++ b/src/mocks/web-animations-api/__tests__/index.test.ts
@@ -36,6 +36,24 @@ describe('Animations API', () => {
     expect(document.getAnimations().length).toBe(0);
   });
 
+  it('should add/delete an animation to/from element and document lists if created manually', async () => {
+    const element = document.createElement('div');
+
+    const keyframeEffect = new KeyframeEffect(element, { opacity: 0 }, 100);
+    const animation = new Animation(keyframeEffect);
+    animation.play();
+
+    expect(element.getAnimations().length).toBe(1);
+    expect(element.getAnimations()).toContain(animation);
+    expect(document.getAnimations().length).toBe(1);
+    expect(document.getAnimations()).toContain(animation);
+
+    await animation.finished;
+
+    expect(element.getAnimations().length).toBe(0);
+    expect(document.getAnimations().length).toBe(0);
+  });
+
   it('should read id from options and attach it to the returned animation', async () => {
     const element = document.createElement('div');
     const testId = 'testId';

--- a/src/mocks/web-animations-api/elementAnimations.ts
+++ b/src/mocks/web-animations-api/elementAnimations.ts
@@ -1,0 +1,32 @@
+const elementAnimations = new Map<Element, Animation[]>();
+
+export function removeAnimation(element: Element, animation: Animation) {
+  const animations = elementAnimations.get(element);
+
+  if (animations) {
+    const index = animations.indexOf(animation);
+
+    if (index !== -1) {
+      animations.splice(index, 1);
+    }
+  }
+}
+
+export function addAnimation(element: Element, animation: Animation) {
+  const animations = elementAnimations.get(element) ?? [];
+  animations.push(animation);
+
+  elementAnimations.set(element, animations);
+}
+
+export function getAnimations(this: Element) {
+  return elementAnimations.get(this) ?? [];
+}
+
+export function getAllAnimations() {
+  return Array.from(elementAnimations.values()).flat();
+}
+
+export function clearAnimations() {
+  elementAnimations.clear();
+}

--- a/src/mocks/web-animations-api/index.ts
+++ b/src/mocks/web-animations-api/index.ts
@@ -2,14 +2,29 @@ import { mockAnimation } from './Animation';
 
 const elementAnimations = new Map<Element, Animation[]>();
 
+function removeFromAnimations(element: Element, animation: Animation) {
+  const animations = elementAnimations.get(element);
+
+  if (animations) {
+    const index = animations.indexOf(animation);
+
+    if (index !== -1) {
+      animations.splice(index, 1);
+    }
+  }
+}
+
 function animate(
   this: Element,
   keyframes: Keyframe[],
-  options?: number | KeyframeEffectOptions
+  options?: number | KeyframeAnimationOptions
 ) {
   const keyframeEffect = new KeyframeEffect(this, keyframes, options);
 
   const animation = new Animation(keyframeEffect);
+  if (typeof options == 'object' && options.id) {
+    animation.id = options.id;
+  }
 
   const animations = elementAnimations.get(this) ?? [];
 
@@ -17,17 +32,12 @@ function animate(
 
   elementAnimations.set(this, animations);
 
-  animation.addEventListener('finish', () => {
-    const animations = elementAnimations.get(this);
-
-    if (animations) {
-      const index = animations.indexOf(animation);
-
-      if (index !== -1) {
-        animations.splice(index, 1);
-      }
-    }
-  });
+  animation.addEventListener('finish', () =>
+    removeFromAnimations(this, animation)
+  );
+  animation.addEventListener('cancel', () =>
+    removeFromAnimations(this, animation)
+  );
 
   animation.play();
 

--- a/src/mocks/web-animations-api/index.ts
+++ b/src/mocks/web-animations-api/index.ts
@@ -1,18 +1,9 @@
 import { mockAnimation } from './Animation';
-
-const elementAnimations = new Map<Element, Animation[]>();
-
-function removeFromAnimations(element: Element, animation: Animation) {
-  const animations = elementAnimations.get(element);
-
-  if (animations) {
-    const index = animations.indexOf(animation);
-
-    if (index !== -1) {
-      animations.splice(index, 1);
-    }
-  }
-}
+import {
+  getAnimations,
+  getAllAnimations,
+  clearAnimations,
+} from './elementAnimations';
 
 function animate(
   this: Element,
@@ -26,30 +17,9 @@ function animate(
     animation.id = options.id;
   }
 
-  const animations = elementAnimations.get(this) ?? [];
-
-  animations.push(animation);
-
-  elementAnimations.set(this, animations);
-
-  animation.addEventListener('finish', () =>
-    removeFromAnimations(this, animation)
-  );
-  animation.addEventListener('cancel', () =>
-    removeFromAnimations(this, animation)
-  );
-
   animation.play();
 
   return animation;
-}
-
-function getAnimations(this: Element) {
-  return elementAnimations.get(this) ?? [];
-}
-
-function getAllAnimations() {
-  return Array.from(elementAnimations.values()).flat();
 }
 
 function mockAnimationsApi() {
@@ -79,7 +49,7 @@ function mockAnimationsApi() {
   });
 
   afterEach(() => {
-    elementAnimations.clear();
+    clearAnimations();
   });
 
   afterAll(() => {


### PR DESCRIPTION
Hi! Using Web Animations API mock i have noticed two moments:

1. passing id to options does nothing, `animation.id` returns null
2. calling `animation.cancel` doesn't delete the animation from `element.getAnimations()`

These moment are easy to fix so i decided to fix it by myself in this PR

What i've done:

**animation.id**
https://developer.mozilla.org/en-US/docs/Web/API/Element/animate
As mentioned in MDN `options` should accept an optional `id` 

1. Change `options` type to KeyframeAnimationOptions
2. If `options` is an object and options.id is defined, attach `options.id` to `animation.id`

**animation.cancel**
I haven't found a description of this behavior in the specification (either in MDN docs) but chrome and FF delete cancelled animations from `element.getAnimations()`

There is an example:
https://codesandbox.io/s/competent-golick-0qwqd1?file=/src/App.js

1. Add `cancel` event listener to an animation
2. Remove the animation from `animations` array

---

Also i've added tests to cover the new functionality