### PR TITLE
Allow import in node.js environment

### DIFF
--- a/src/mocks/MediaQueryListEvent.ts
+++ b/src/mocks/MediaQueryListEvent.ts
@@ -13,7 +13,7 @@ export class MockedMediaQueryListEvent
   }
 }
 
-if (typeof MediaQueryListEvent === 'undefined') {
+if (typeof MediaQueryListEvent === 'undefined' && typeof window !== 'undefined') {
   Object.defineProperty(window, 'MediaQueryListEvent', {
     writable: true,
     configurable: true,

--- a/src/mocks/resize-observer.ts
+++ b/src/mocks/resize-observer.ts
@@ -1,8 +1,6 @@
 import { RequireAtLeastOne } from 'type-fest';
 import { getConfig } from '../tools';
 
-const config = getConfig();
-
 type Sizes = {
   borderBoxSize: ResizeObserverSize[];
   contentBoxSize: ResizeObserverSize[];
@@ -17,75 +15,61 @@ type SizeInput = {
 
 type Size = RequireAtLeastOne<SizeInput>;
 
-type State = {
-  observers: MockedResizeObserver[];
-  targetObservers: Map<HTMLElement, MockedResizeObserver[]>;
-  elementSizes: Map<HTMLElement, Sizes>;
-};
+function getResizeObserver(window: Window & { ResizeObserver?: unknown }) {
+  const config = getConfig();
 
-const state: State = {
-  observers: [],
-  targetObservers: new Map(),
-  elementSizes: new Map(),
-};
-
-function resetState() {
-  state.observers = [];
-  state.targetObservers = new Map();
-  state.elementSizes = new Map();
-}
-
-function defineResizeObserverSize(
-  input: ResizeObserverSizeInput
-): ResizeObserverSize {
-  return {
-    blockSize: input.blockSize ?? 0,
-    inlineSize: input.inlineSize ?? 0,
+  type State = {
+    observers: MockedResizeObserver[];
+    targetObservers: Map<HTMLElement, MockedResizeObserver[]>;
+    elementSizes: Map<HTMLElement, Sizes>;
   };
-}
 
-class MockedResizeObserver implements ResizeObserver {
-  callback: ResizeObserverCallback;
-  observationTargets = new Set<HTMLElement>();
-  activeTargets = new Set<HTMLElement>();
+  const state: State = {
+    observers: [],
+    targetObservers: new Map(),
+    elementSizes: new Map(),
+  };
 
-  constructor(callback: ResizeObserverCallback) {
-    this.callback = callback;
-    state.observers.push(this);
+  function resetState() {
+    state.observers = [];
+    state.targetObservers = new Map();
+    state.elementSizes = new Map();
   }
 
-  observe = (node: HTMLElement) => {
-    this.observationTargets.add(node);
-    this.activeTargets.add(node);
+  function defineResizeObserverSize(
+    input: ResizeObserverSizeInput
+  ): ResizeObserverSize {
+    return {
+      blockSize: input.blockSize ?? 0,
+      inlineSize: input.inlineSize ?? 0,
+    };
+  }
 
-    if (state.targetObservers.has(node)) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      state.targetObservers.get(node)!.push(this);
-    } else {
-      state.targetObservers.set(node, [this]);
+  class MockedResizeObserver implements ResizeObserver {
+    callback: ResizeObserverCallback;
+    observationTargets = new Set<HTMLElement>();
+    activeTargets = new Set<HTMLElement>();
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+      state.observers.push(this);
     }
-  };
 
-  unobserve = (node: HTMLElement) => {
-    this.observationTargets.delete(node);
+    observe = (node: HTMLElement) => {
+      this.observationTargets.add(node);
+      this.activeTargets.add(node);
 
-    const targetObservers = state.targetObservers.get(node);
-
-    if (targetObservers) {
-      const index = targetObservers.findIndex((mro) => mro === this);
-
-      targetObservers.splice(index, 1);
-
-      if (targetObservers.length === 0) {
-        state.targetObservers.delete(node);
+      if (state.targetObservers.has(node)) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        state.targetObservers.get(node)!.push(this);
+      } else {
+        state.targetObservers.set(node, [this]);
       }
-    }
-  };
+    };
 
-  disconnect = () => {
-    this.observationTargets.clear();
+    unobserve = (node: HTMLElement) => {
+      this.observationTargets.delete(node);
 
-    for (const node of this.observationTargets) {
       const targetObservers = state.targetObservers.get(node);
 
       if (targetObservers) {
@@ -97,203 +81,223 @@ class MockedResizeObserver implements ResizeObserver {
           state.targetObservers.delete(node);
         }
       }
-    }
-  };
-}
+    };
 
-function elementToEntry(element: HTMLElement): ResizeObserverEntry | null {
-  const boundingClientRect = element.getBoundingClientRect();
-  let sizes = state.elementSizes.get(element);
+    disconnect = () => {
+      this.observationTargets.clear();
 
-  if (!sizes) {
-    sizes = {
-      borderBoxSize: [
-        {
-          blockSize: boundingClientRect.width,
-          inlineSize: boundingClientRect.height,
-        },
-      ],
-      contentBoxSize: [
-        {
-          blockSize: boundingClientRect.width,
-          inlineSize: boundingClientRect.height,
-        },
-      ],
-      contentRect: boundingClientRect,
+      for (const node of this.observationTargets) {
+        const targetObservers = state.targetObservers.get(node);
+
+        if (targetObservers) {
+          const index = targetObservers.findIndex((mro) => mro === this);
+
+          targetObservers.splice(index, 1);
+
+          if (targetObservers.length === 0) {
+            state.targetObservers.delete(node);
+          }
+        }
+      }
     };
   }
 
-  if (sizes.contentRect.width === 0 && sizes.contentRect.height === 0) {
-    return null;
+  function elementToEntry(element: HTMLElement): ResizeObserverEntry | null {
+    const boundingClientRect = element.getBoundingClientRect();
+    let sizes = state.elementSizes.get(element);
+
+    if (!sizes) {
+      sizes = {
+        borderBoxSize: [
+          {
+            blockSize: boundingClientRect.width,
+            inlineSize: boundingClientRect.height,
+          },
+        ],
+        contentBoxSize: [
+          {
+            blockSize: boundingClientRect.width,
+            inlineSize: boundingClientRect.height,
+          },
+        ],
+        contentRect: boundingClientRect,
+      };
+    }
+
+    if (sizes.contentRect.width === 0 && sizes.contentRect.height === 0) {
+      return null;
+    }
+
+    return {
+      borderBoxSize: Object.freeze(sizes.borderBoxSize),
+      contentBoxSize: Object.freeze(sizes.contentBoxSize),
+      contentRect: sizes.contentRect,
+      devicePixelContentBoxSize: Object.freeze(
+        sizes.contentBoxSize.map((size) => ({
+          blockSize: size.blockSize * window.devicePixelRatio,
+          inlineSize: size.inlineSize * window.devicePixelRatio,
+        }))
+      ),
+      target: element,
+    };
   }
 
-  return {
-    borderBoxSize: Object.freeze(sizes.borderBoxSize),
-    contentBoxSize: Object.freeze(sizes.contentBoxSize),
-    contentRect: sizes.contentRect,
-    devicePixelContentBoxSize: Object.freeze(
-      sizes.contentBoxSize.map((size) => ({
-        blockSize: size.blockSize * window.devicePixelRatio,
-        inlineSize: size.inlineSize * window.devicePixelRatio,
-      }))
-    ),
-    target: element,
-  };
-}
+  function mockResizeObserver() {
+    const savedImplementation = window.ResizeObserver;
 
-function mockResizeObserver() {
-  const savedImplementation = window.ResizeObserver;
+    Object.defineProperty(window, 'ResizeObserver', {
+      writable: true,
+      configurable: true,
+      value: MockedResizeObserver,
+    });
 
-  Object.defineProperty(window, 'ResizeObserver', {
-    writable: true,
-    configurable: true,
-    value: MockedResizeObserver,
-  });
+    config.afterEach(() => {
+      resetState();
+    });
 
-  config.afterEach(() => {
-    resetState();
-  });
+    config.afterAll(() => {
+      window.ResizeObserver = savedImplementation;
+    });
 
-  config.afterAll(() => {
-    window.ResizeObserver = savedImplementation;
-  });
-
-  return {
-    getObservers: (element?: HTMLElement) => {
-      if (element) {
-        return [...(state.targetObservers.get(element) ?? [])];
-      }
-
-      return [...state.observers];
-    },
-    getObservedElements: (observer?: ResizeObserver) => {
-      if (observer) {
-        return [...(observer as MockedResizeObserver).observationTargets];
-      }
-
-      return [...state.targetObservers.keys()];
-    },
-    mockElementSize: (element: HTMLElement, size: Size) => {
-      let contentBoxSize: ResizeObserverSize[];
-      let borderBoxSize: ResizeObserverSize[];
-
-      if (!size.borderBoxSize && size.contentBoxSize) {
-        if (!Array.isArray(size.contentBoxSize)) {
-          size.contentBoxSize = [size.contentBoxSize];
+    return {
+      getObservers: (element?: HTMLElement) => {
+        if (element) {
+          return [...(state.targetObservers.get(element) ?? [])];
         }
 
-        contentBoxSize = size.contentBoxSize.map(defineResizeObserverSize);
-        borderBoxSize = contentBoxSize;
-      } else if (size.borderBoxSize && !size.contentBoxSize) {
-        if (!Array.isArray(size.borderBoxSize)) {
-          size.borderBoxSize = [size.borderBoxSize];
+        return [...state.observers];
+      },
+      getObservedElements: (observer?: ResizeObserver) => {
+        if (observer) {
+          return [...(observer as MockedResizeObserver).observationTargets];
         }
 
-        contentBoxSize = size.borderBoxSize.map(defineResizeObserverSize);
-        borderBoxSize = contentBoxSize;
-      } else if (size.borderBoxSize && size.contentBoxSize) {
-        if (!Array.isArray(size.borderBoxSize)) {
-          size.borderBoxSize = [size.borderBoxSize];
-        }
+        return [...state.targetObservers.keys()];
+      },
+      mockElementSize: (element: HTMLElement, size: Size) => {
+        let contentBoxSize: ResizeObserverSize[];
+        let borderBoxSize: ResizeObserverSize[];
 
-        if (!Array.isArray(size.contentBoxSize)) {
-          size.contentBoxSize = [size.contentBoxSize];
-        }
-
-        contentBoxSize = size.contentBoxSize.map(defineResizeObserverSize);
-        borderBoxSize = size.borderBoxSize.map(defineResizeObserverSize);
-
-        if (borderBoxSize.length !== contentBoxSize.length) {
-          throw new Error(
-            'Both borderBoxSize and contentBoxSize must have the same amount of elements.'
-          );
-        }
-      } else {
-        throw new Error(
-          'Neither borderBoxSize nor contentBoxSize was provided.'
-        );
-      }
-
-      // verify contentBoxSize and borderBoxSize are not negative
-      contentBoxSize.forEach((size, index) => {
-        if (size.blockSize < 0) {
-          throw new Error(
-            `contentBoxSize[${index}].blockSize must not be negative.`
-          );
-        }
-
-        if (size.inlineSize < 0) {
-          throw new Error(
-            `contentBoxSize[${index}].inlineSize must not be negative.`
-          );
-        }
-      });
-
-      borderBoxSize.forEach((size, index) => {
-        if (size.blockSize < 0) {
-          throw new Error(
-            `borderBoxSize[${index}].blockSize must not be negative.`
-          );
-        }
-
-        if (size.inlineSize < 0) {
-          throw new Error(
-            `borderBoxSize[${index}].inlineSize must not be negative.`
-          );
-        }
-      });
-
-      const contentRect = new DOMRect(
-        0,
-        0,
-        contentBoxSize.reduce((acc, size) => acc + size.inlineSize, 0),
-        contentBoxSize.reduce((acc, size) => acc + size.blockSize, 0)
-      );
-
-      state.elementSizes.set(element, {
-        contentBoxSize,
-        borderBoxSize,
-        contentRect,
-      });
-    },
-    resize: (
-      elements: HTMLElement | HTMLElement[] = [],
-      { ignoreImplicit = false } = {}
-    ) => {
-      config.act(() => {
-        if (!Array.isArray(elements)) {
-          elements = [elements];
-        }
-
-        for (const observer of state.observers) {
-          const observedSubset = elements.filter((element) =>
-            observer.observationTargets.has(element)
-          );
-
-          const observedSubsetAndActive = new Set([
-            ...observedSubset,
-            ...(ignoreImplicit ? [] : observer.activeTargets),
-          ]);
-
-          observer.activeTargets.clear();
-
-          const entries = Array.from(observedSubsetAndActive)
-            .map(elementToEntry)
-            .filter(Boolean) as ResizeObserverEntry[];
-
-          if (entries.length > 0) {
-            observer.callback(entries, observer);
+        if (!size.borderBoxSize && size.contentBoxSize) {
+          if (!Array.isArray(size.contentBoxSize)) {
+            size.contentBoxSize = [size.contentBoxSize];
           }
+
+          contentBoxSize = size.contentBoxSize.map(defineResizeObserverSize);
+          borderBoxSize = contentBoxSize;
+        } else if (size.borderBoxSize && !size.contentBoxSize) {
+          if (!Array.isArray(size.borderBoxSize)) {
+            size.borderBoxSize = [size.borderBoxSize];
+          }
+
+          contentBoxSize = size.borderBoxSize.map(defineResizeObserverSize);
+          borderBoxSize = contentBoxSize;
+        } else if (size.borderBoxSize && size.contentBoxSize) {
+          if (!Array.isArray(size.borderBoxSize)) {
+            size.borderBoxSize = [size.borderBoxSize];
+          }
+
+          if (!Array.isArray(size.contentBoxSize)) {
+            size.contentBoxSize = [size.contentBoxSize];
+          }
+
+          contentBoxSize = size.contentBoxSize.map(defineResizeObserverSize);
+          borderBoxSize = size.borderBoxSize.map(defineResizeObserverSize);
+
+          if (borderBoxSize.length !== contentBoxSize.length) {
+            throw new Error(
+              'Both borderBoxSize and contentBoxSize must have the same amount of elements.'
+            );
+          }
+        } else {
+          throw new Error(
+            'Neither borderBoxSize nor contentBoxSize was provided.'
+          );
         }
-      });
-    },
-  };
+
+        // verify contentBoxSize and borderBoxSize are not negative
+        contentBoxSize.forEach((size, index) => {
+          if (size.blockSize < 0) {
+            throw new Error(
+              `contentBoxSize[${index}].blockSize must not be negative.`
+            );
+          }
+
+          if (size.inlineSize < 0) {
+            throw new Error(
+              `contentBoxSize[${index}].inlineSize must not be negative.`
+            );
+          }
+        });
+
+        borderBoxSize.forEach((size, index) => {
+          if (size.blockSize < 0) {
+            throw new Error(
+              `borderBoxSize[${index}].blockSize must not be negative.`
+            );
+          }
+
+          if (size.inlineSize < 0) {
+            throw new Error(
+              `borderBoxSize[${index}].inlineSize must not be negative.`
+            );
+          }
+        });
+
+        const contentRect = new DOMRect(
+          0,
+          0,
+          contentBoxSize.reduce((acc, size) => acc + size.inlineSize, 0),
+          contentBoxSize.reduce((acc, size) => acc + size.blockSize, 0)
+        );
+
+        state.elementSizes.set(element, {
+          contentBoxSize,
+          borderBoxSize,
+          contentRect,
+        });
+      },
+      resize: (
+        elements: HTMLElement | HTMLElement[] = [],
+        { ignoreImplicit = false } = {}
+      ) => {
+        config.act(() => {
+          if (!Array.isArray(elements)) {
+            elements = [elements];
+          }
+
+          for (const observer of state.observers) {
+            const observedSubset = elements.filter((element) =>
+              observer.observationTargets.has(element)
+            );
+
+            const observedSubsetAndActive = new Set([
+              ...observedSubset,
+              ...(ignoreImplicit ? [] : observer.activeTargets),
+            ]);
+
+            observer.activeTargets.clear();
+
+            const entries = Array.from(observedSubsetAndActive)
+              .map(elementToEntry)
+              .filter(Boolean) as ResizeObserverEntry[];
+
+            if (entries.length > 0) {
+              observer.callback(entries, observer);
+            }
+          }
+        });
+      },
+    };
+  }
+
+  const { mockElementSize } = mockResizeObserver();
+
+  mockElementSize(document.body, {
+    contentBoxSize: [{ blockSize: 100, inlineSize: 100 }],
+  });
 }
 
-const { mockElementSize } = mockResizeObserver();
-
-mockElementSize(document.body, {
-  contentBoxSize: [{ blockSize: 100, inlineSize: 100 }],
-});
+const mockResizeObserver = typeof window !== 'undefined' ? getResizeObserver(window) : undefined;
 
 export { mockResizeObserver };

--- a/src/mocks/size/DOMRect.ts
+++ b/src/mocks/size/DOMRect.ts
@@ -149,7 +149,7 @@ export class MockedDOMRect extends MockedDOMRectReadOnly implements DOMRect {
   }
 }
 
-if (typeof DOMRectReadOnly === 'undefined') {
+if (typeof window !== 'undefined' && typeof DOMRectReadOnly === 'undefined') {
   Object.defineProperty(window, 'DOMRectReadOnly', {
     writable: true,
     configurable: true,
@@ -157,7 +157,7 @@ if (typeof DOMRectReadOnly === 'undefined') {
   });
 }
 
-if (typeof DOMRect === 'undefined') {
+if (typeof window !== 'undefined' && typeof DOMRect === 'undefined') {
   Object.defineProperty(window, 'DOMRect', {
     writable: true,
     configurable: true,

--- a/src/mocks/web-animations-api/Animation.ts
+++ b/src/mocks/web-animations-api/Animation.ts
@@ -1737,7 +1737,7 @@ function mockAnimation() {
   mockAnimationPlaybackEvent();
   mockDocumentTimeline();
 
-  if (typeof Animation === 'undefined') {
+  if (typeof Animation === 'undefined' && typeof window !== 'undefined') {
     Object.defineProperty(window, 'Animation', {
       writable: true,
       configurable: true,

--- a/src/mocks/web-animations-api/__tests__/node.test.ts
+++ b/src/mocks/web-animations-api/__tests__/node.test.ts
@@ -1,0 +1,10 @@
+/**
+ * @jest-environment node
+ */
+
+import '../../../index';
+
+
+test('the library can be imported in a node environment', () => {
+    expect(() => { window }).toThrowError('window is not defined');
+});


### PR DESCRIPTION
This is a fix for #49 to avoid import errors in a node environment.

Check if all instances of 'window' are defined before use.

Use dependency injection for ResizeObserver (Really just a function wrapper. It is a big diff though).

Added a test case for node environment.