### PR TITLE
Fix ResizeObserver.disconnect

### DIFF
--- a/src/mocks/resize-observer.ts
+++ b/src/mocks/resize-observer.ts
@@ -85,8 +85,6 @@ class MockedResizeObserver implements ResizeObserver {
   };
 
   disconnect = () => {
-    this.observationTargets.clear();
-
     for (const node of this.observationTargets) {
       const targetObservers = state.targetObservers.get(node);
 
@@ -100,6 +98,8 @@ class MockedResizeObserver implements ResizeObserver {
         }
       }
     }
+
+    this.observationTargets.clear();
   };
 }
 


### PR DESCRIPTION
The mock `disconnect` method was clearing the collection of observed targets before attempting to remove those observed targets from the global state. This causes the collection to always be empty.

This fix clears the global state before clearing the local collection of observed targets.