### PR TITLE
feat: add CSSNumberish support with type-safe conversion helpers

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,12 +1,41 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Mock as ViMock } from 'vitest';
+
+// By re-declaring the vitest module, we can augment its types.
+declare module 'vitest' {
+  /**
+   * Augment vitest's Mock type to be compatible with jest.Mock.
+   * This allows us to use a single, consistent type for mocks across both test runners.
+   */
+  export interface Mock<A extends unknown[] = unknown[], R = unknown>
+    extends jest.Mock<A, R> {}
+
+  /**
+   * Augment vitest's SpyInstance to be compatible with jest.SpyInstance.
+   * Note the swapped generic arguments:
+   * - Vitest: SpyInstance<[Args], ReturnValue>
+   * - Jest: SpyInstance<ReturnValue, [Args]>
+   * This declaration makes them interoperable.
+   */
+  export interface SpyInstance<A extends unknown[] = unknown[], R = unknown>
+    extends jest.SpyInstance<R, A> {}
+}
+
 export {};
+
+interface Runner {
+  name: 'vi' | 'jest';
+  useFakeTimers: () => void;
+  useRealTimers: () => void;
+  advanceTimersByTime: (time: number) => Promise<void> | void;
+  /** A generic function to create a mock function, compatible with both runners. */
+  fn: () => jest.Mock<unknown[], unknown>;
+  /** A generic function to spy on a method, compatible with both runners. */
+  spyOn: typeof jest.spyOn;
+}
 
 declare global {
   // eslint-disable-next-line no-var
-  var runner: {
-    name: 'vi' | 'jest';
-    useFakeTimers: () => void;
-    useRealTimers: () => void;
-    advanceTimersByTime: (time: number) => Promise<void>;
-    fn: () => jest.Mock<any, any>;
-  };
+  var runner: Runner;
 }

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -14,10 +14,15 @@ function fn() {
   return jest.fn();
 }
 
+function spyOn(...args: Parameters<typeof jest.spyOn>) {
+  return jest.spyOn(...args);
+}
+
 globalThis.runner = {
   name: 'jest',
   useFakeTimers,
   useRealTimers,
   advanceTimersByTime,
   fn,
+  spyOn,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsdom-testing-mocks",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "author": "Ivan Galiatin",
   "license": "MIT",
   "description": "A set of tools for emulating browser behavior in jsdom environment",

--- a/src/mocks/web-animations-api/AnimationEffect.ts
+++ b/src/mocks/web-animations-api/AnimationEffect.ts
@@ -1,3 +1,5 @@
+import { cssNumberishToNumber } from './cssNumberishHelpers';
+
 class MockedAnimationEffect implements AnimationEffect {
   #timing: EffectTiming = {
     delay: 0,
@@ -22,7 +24,8 @@ class MockedAnimationEffect implements AnimationEffect {
       return 0;
     }
 
-    return this.#timing.duration ?? 0;
+    const durationNum = cssNumberishToNumber(this.#timing.duration ?? null);
+    return durationNum ?? 0;
   }
 
   getTiming() {

--- a/src/mocks/web-animations-api/KeyframeEffect.ts
+++ b/src/mocks/web-animations-api/KeyframeEffect.ts
@@ -1,4 +1,5 @@
 import { mockAnimationEffect, MockedAnimationEffect } from './AnimationEffect';
+import { cssNumberishToNumber } from './cssNumberishHelpers';
 
 /**
   Given the structure of PropertyIndexedKeyframes as such:
@@ -87,7 +88,41 @@ class MockedKeyframeEffect
     // not actually implemented, just to make ts happy
     this.iterationComposite = iterationComposite || 'replace';
     this.pseudoElement = pseudoElement || null;
-    this.updateTiming(timing);
+
+    // Only update timing if options were provided
+    if (Object.keys(timing).length > 0) {
+      // Convert CSSNumberish values to numbers for updateTiming
+      const convertedTiming: OptionalEffectTiming = {};
+      
+      if (timing.delay !== undefined) {
+        convertedTiming.delay = cssNumberishToNumber(timing.delay) ?? timing.delay;
+      }
+      if (timing.duration !== undefined) {
+        convertedTiming.duration = typeof timing.duration === 'string' ? timing.duration : cssNumberishToNumber(timing.duration) ?? 0;
+      }
+      if (timing.endDelay !== undefined) {
+        convertedTiming.endDelay = cssNumberishToNumber(timing.endDelay) ?? timing.endDelay;
+      }
+      if (timing.iterationStart !== undefined) {
+        convertedTiming.iterationStart = cssNumberishToNumber(timing.iterationStart) ?? timing.iterationStart;
+      }
+      if (timing.iterations !== undefined) {
+        convertedTiming.iterations = cssNumberishToNumber(timing.iterations) ?? timing.iterations;
+      }
+      if (timing.direction !== undefined) {
+        convertedTiming.direction = timing.direction;
+      }
+      if (timing.easing !== undefined) {
+        convertedTiming.easing = timing.easing;
+      }
+      if (timing.fill !== undefined) {
+        convertedTiming.fill = timing.fill;
+      }
+      if (timing.playbackRate !== undefined) {
+        convertedTiming.playbackRate = timing.playbackRate;
+      }
+      this.updateTiming(convertedTiming);
+    }
   }
 
   #validateKeyframes(keyframes: Keyframe[]) {

--- a/src/mocks/web-animations-api/__tests__/DocumentTimeline.test.ts
+++ b/src/mocks/web-animations-api/__tests__/DocumentTimeline.test.ts
@@ -1,4 +1,5 @@
 import { mockDocumentTimeline } from '../DocumentTimeline';
+import { cssNumberishToNumber } from '../cssNumberishHelpers';
 
 mockDocumentTimeline();
 runner.useFakeTimers();
@@ -18,8 +19,11 @@ describe('DocumentTimeline', () => {
   it('should set default origin time to 0', () => {
     const timeline = new DocumentTimeline();
 
-    expect((timeline.currentTime ?? 0) / 10).toBeCloseTo(
-      (document.timeline.currentTime ?? 0) / 10,
+    const timelineCurrentTime = cssNumberishToNumber(timeline.currentTime) ?? 0;
+    const documentCurrentTime = cssNumberishToNumber(document.timeline.currentTime) ?? 0;
+
+    expect(timelineCurrentTime / 10).toBeCloseTo(
+      documentCurrentTime / 10,
       1
     );
   });
@@ -27,8 +31,11 @@ describe('DocumentTimeline', () => {
   it('should set origin time to the given value', () => {
     const timeline = new DocumentTimeline({ originTime: 100 });
 
-    expect(timeline.currentTime ?? 0).toBeCloseTo(
-      (document.timeline.currentTime ?? 0) - 100,
+    const timelineCurrentTime = cssNumberishToNumber(timeline.currentTime) ?? 0;
+    const documentCurrentTime = cssNumberishToNumber(document.timeline.currentTime) ?? 0;
+
+    expect(timelineCurrentTime).toBeCloseTo(
+      documentCurrentTime - 100,
       0
     );
   });

--- a/src/mocks/web-animations-api/__tests__/cssNumberishHelpers.test.ts
+++ b/src/mocks/web-animations-api/__tests__/cssNumberishHelpers.test.ts
@@ -1,0 +1,61 @@
+import { cssNumberishToNumber } from '../cssNumberishHelpers';
+
+// Mock CSSUnitValue for testing since it's not in the default JSDOM env
+class MockCSSUnitValue {
+  value: number;
+  unit: string;
+  constructor(value: number, unit: string) {
+    this.value = value;
+    this.unit = unit;
+  }
+}
+
+// @ts-ignore
+global.CSSUnitValue = MockCSSUnitValue;
+
+describe('cssNumberishHelpers', () => {
+  describe('cssNumberishToNumber', () => {
+    it('should return null if the input is null', () => {
+      expect(cssNumberishToNumber(null)).toBeNull();
+    });
+
+    it('should return the same number if the input is a number', () => {
+      expect(cssNumberishToNumber(100)).toBe(100);
+    });
+
+    it('should convert seconds to milliseconds', () => {
+      const twoSeconds = new CSSUnitValue(2, 's');
+      expect(cssNumberishToNumber(twoSeconds)).toBe(2000);
+    });
+
+    it('should return the same value for milliseconds', () => {
+      const twoHundredMs = new CSSUnitValue(200, 'ms');
+      expect(cssNumberishToNumber(twoHundredMs)).toBe(200);
+    });
+
+    it('should return null for non-time units like px', () => {
+      const oneHundredPx = new CSSUnitValue(100, 'px');
+      expect(cssNumberishToNumber(oneHundredPx)).toBeNull();
+    });
+
+    it('should return null and warn for unsupported CSSMathValue', () => {
+      // Mock CSSMathValue
+      class MockCSSMathValue {}
+      // @ts-ignore
+      global.CSSMathValue = MockCSSMathValue;
+
+      const consoleWarnSpy = runner.spyOn(console, 'warn').mockImplementation(() => {
+        // This is a mock implementation to prevent console output during the test.
+      });
+
+      const mathValue = new MockCSSMathValue();
+      // @ts-ignore
+      expect(cssNumberishToNumber(mathValue)).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'jsdom-testing-mocks: Complex CSSNumericValue (like calc()) are not supported. Returning null.'
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
+  });
+}); 

--- a/src/mocks/web-animations-api/cssNumberishHelpers.ts
+++ b/src/mocks/web-animations-api/cssNumberishHelpers.ts
@@ -1,0 +1,68 @@
+/**
+ * Helper functions for converting between CSSNumberish and number types
+ * 
+ * CSSNumberish can be either a number or CSSNumericValue, but most of our
+ * internal logic works with numbers. These helpers provide safe conversion
+ * at the boundaries between public APIs and internal implementation.
+ */
+
+/**
+ * Converts CSSNumberish to number, handling null and CSSUnitValue values.
+ * It's aware of time units and converts them to milliseconds, as the
+ * Web Animations API typically works with milliseconds. For unsupported types
+ * like CSSMathValue (e.g., calc()), it will return null and log a warning.
+ * 
+ * @param value - The CSSNumberish value to convert
+ * @returns The number value in milliseconds, or null if the input is null or cannot be converted
+ */
+export function cssNumberishToNumber(value: CSSNumberish | null): number | null {
+  if (value === null) return null;
+  if (typeof value === 'number') return value;
+
+  // Handle CSSUnitValue (e.g., CSS.s(2), CSS.ms(500))
+  // We do a safe check in case the class doesn't exist in the JSDOM environment.
+  if (typeof CSSUnitValue !== 'undefined' && value instanceof CSSUnitValue) {
+    if (value.unit === 's') {
+      return value.value * 1000; // Convert seconds to milliseconds
+    }
+    if (value.unit === 'ms' || value.unit === 'number') {
+      return value.value;
+    }
+    // For other units like 'px', '%', etc., we can't convert to a timeline value.
+    console.warn(`jsdom-testing-mocks: Unsupported CSS unit '${value.unit}' in cssNumberishToNumber. Returning null.`);
+    return null;
+  }
+  
+  // Handle complex CSSNumericValue types that are not supported by this mock
+  if (
+    (typeof CSSMathValue !== 'undefined' && value instanceof CSSMathValue)
+  ) {
+    console.warn(
+      `jsdom-testing-mocks: Complex CSSNumericValue (like calc()) are not supported. Returning null.`
+    );
+    return null;
+  }
+
+  // Fallback for any other unknown case. This is unlikely to be hit.
+  return Number(value);
+}
+
+/**
+ * Converts number to CSSNumberish
+ * @param value - The number value to convert
+ * @returns The CSSNumberish value, or null if the input is null
+ */
+export function numberToCSSNumberish(value: number | null): CSSNumberish | null {
+  return value;
+}
+
+/**
+ * Converts CSSNumberish to number with a default value
+ * @param value - The CSSNumberish value to convert
+ * @param defaultValue - The default value to return if conversion fails
+ * @returns The number value, or the default value if conversion fails
+ */
+export function cssNumberishToNumberWithDefault(value: CSSNumberish | null, defaultValue: number): number {
+  const converted = cssNumberishToNumber(value);
+  return converted ?? defaultValue;
+} 

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -28,10 +28,15 @@ function fn() {
   return vi.fn();
 }
 
+function spyOn(...args: Parameters<typeof vi.spyOn>) {
+  return vi.spyOn(...args);
+}
+
 globalThis.runner = {
   name: 'vi',
   useFakeTimers,
   useRealTimers,
   advanceTimersByTime,
   fn,
+  spyOn,
 };


### PR DESCRIPTION
## 🎯 Overview

This PR adds comprehensive support for the `CSSNumberish` type introduced in the Web Animations API, replacing the previous `number` type for timing properties.

## ✨ Key Changes

### New Features
- **CSSNumberish Helper Module**: Centralized conversion utilities in `cssNumberishHelpers.ts`
- **Type-Safe Conversions**: Robust handling of `CSSUnitValue` (time units) and `CSSMathValue`
- **Cross-Runner Compatibility**: Enhanced `runner` abstraction with `spyOn` support
- **Comprehensive Testing**: Unit tests for helpers + integration tests across all runners

### Technical Improvements
- **Boundary-Layer Pattern**: Convert `CSSNumberish` to `number` at API boundaries
- **Zero `any` Types**: Complete elimination of `any` in favor of `unknown`
- **Graceful Degradation**: Safe handling of unsupported CSS units with warnings
- **Environment Awareness**: JSDOM-compatible checks for browser APIs

## 🧪 Testing

All tests pass across:
- ✅ Jest
- ✅ Vitest  
- ✅ SWC
- ✅ Examples

## 📦 Version

Bumps to `1.14.0` - new feature release

## 🔧 Breaking Changes

None - this is a backward-compatible enhancement that maintains existing API contracts while adding support for the new `CSSNumberish` type.