### PR TITLE
Fix ReferenceError: module is not defined in ES module scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "react"
   ],
   "main": "dist/index.js",
+  "exports": {
+    "import":"./dist/esm/index.js",
+    "require": "./dist/index.js"
+  },
   "typings": "dist/index.d.ts",
   "files": [
     "/dist",


### PR DESCRIPTION
Thanks for this package! Something changed recently with Vitest and it's producing an error when a package doesn't use the `exports` field.

<img width="2984" height="826" alt="CleanShot 2025-07-29 at 11  37 11@2x" src="https://github.com/user-attachments/assets/b6a0a3d6-f1b8-4b69-96f7-0fac92600e2f" />
